### PR TITLE
conf: enable rules for sonarlint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
           <basePlugin>openedge</basePlugin>
           <requirePlugins>openedge:3.0.0</requirePlugins>
           <pluginApiMinVersion>9.14</pluginApiMinVersion>
+          <sonarLintSupported>true</sonarLintSupported>
           <skipDependenciesPackaging>true</skipDependenciesPackaging>
           <archive>
             <manifestEntries>


### PR DESCRIPTION
To avoid those kind of messages : 

```
  * oe: 21 active rules
Rule my-rules:com.my.rules.UnusedVarRule is enabled on the server, but not available in SonarLint
Rule my-rules:com.my.rules.NoPrivateUcRule is enabled on the server, but not available in SonarLint
Rule my-rules:com.my.rules.NoPublicVarRule is enabled on the server, but not available in SonarLint
Rule my-rules:com.my.rules.OneLetterVarRule is enabled on the server, but not available in SonarLint
```